### PR TITLE
RHTAPSRE-392: Use machine pool for CPU intensive pipelines

### DIFF
--- a/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
@@ -17,6 +17,15 @@ metadata:
   name: openvino-model-server-2023-1-release-on-pull-request
   namespace: rhoai-tenant
 spec:
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        pipeline-type: build
+      tolerations:
+        - key: pipeline-type
+          operator: Equal
+          value: build
+          effect: NoSchedule
   params:
   - name: dockerfile
     value: Dockerfile.redhat
@@ -371,7 +380,6 @@ spec:
     - name: workspace
     - name: git-auth
       optional: true
-  taskRunTemplate: {}
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
@@ -26,6 +26,8 @@ spec:
           operator: Equal
           value: build
           effect: NoSchedule
+  timeouts:
+    pipeline: "4h"
   params:
   - name: dockerfile
     value: Dockerfile.redhat
@@ -233,6 +235,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      timeout: 4h
       when:
       - input: $(tasks.init.results.build)
         operator: in

--- a/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
@@ -227,9 +227,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah
+          value: buildah-24gb
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:163009699fca1c5c043516d84986b44f8b6ef25418c97eed51d12518a94d552e
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-24gb@sha256:72c4f3d797eaaf6b350c8b1a4ff0b1503222370ad9d7e9ff1304e8c258c60f8c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
           value: build
           effect: NoSchedule
   timeouts:
-    pipeline: "4h"
+    pipeline: "6h"
   params:
   - name: dockerfile
     value: Dockerfile.redhat
@@ -235,7 +235,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      timeout: 4h
+      timeout: 6h
       when:
       - input: $(tasks.init.results.build)
         operator: in

--- a/.tekton/openvino-model-server-2023-1-release-push.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-push.yaml
@@ -16,6 +16,15 @@ metadata:
   name: openvino-model-server-2023-1-release-on-push
   namespace: rhoai-tenant
 spec:
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        pipeline-type: build
+      tolerations:
+        - key: pipeline-type
+          operator: Equal
+          value: build
+          effect: NoSchedule
   timeouts:
     pipeline: "8h"
   params:
@@ -371,7 +380,6 @@ spec:
     - name: workspace
     - name: git-auth
       optional: true
-  taskRunTemplate: {}
   workspaces:
   - name: workspace
     volumeClaimTemplate:

--- a/.tekton/openvino-model-server-2023-1-release-push.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-push.yaml
@@ -228,7 +228,7 @@ spec:
         - name: name
           value: buildah-24gb
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-24gb:0.1@sha256:82791044944c75a0b3268991a3c52172a34b6b5940159bc1bc6a01f44c1d98c8
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-24gb@sha256:72c4f3d797eaaf6b350c8b1a4ff0b1503222370ad9d7e9ff1304e8c258c60f8c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/openvino-model-server-2023-1-release-push.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-push.yaml
@@ -26,7 +26,7 @@ spec:
           value: build
           effect: NoSchedule
   timeouts:
-    pipeline: "8h"
+    pipeline: 4h
   params:
   - name: dockerfile
     value: Dockerfile.redhat
@@ -232,7 +232,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      timeout: "6h"
+      timeout: 4h
       when:
       - input: $(tasks.init.results.build)
         operator: in

--- a/.tekton/openvino-model-server-2023-1-release-push.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-push.yaml
@@ -26,7 +26,7 @@ spec:
           value: build
           effect: NoSchedule
   timeouts:
-    pipeline: 4h
+    pipeline: 6h
   params:
   - name: dockerfile
     value: Dockerfile.redhat
@@ -232,7 +232,7 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      timeout: 4h
+      timeout: 6h
       when:
       - input: $(tasks.init.results.build)
         operator: in


### PR DESCRIPTION
Use a machine pool that provides machines with 32 vcpus and 64GB of RAM.