### PR TITLE
fix(KONFLUX-3663): format PipelineRun files and upload SAST results

### DIFF
--- a/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-pull-request.yaml
@@ -317,7 +317,7 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
       taskRef:
         params:
         - name: name
@@ -335,6 +335,11 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/openvino-model-server-2023-1-release-push.yaml
+++ b/.tekton/openvino-model-server-2023-1-release-push.yaml
@@ -314,7 +314,7 @@ spec:
         - "false"
     - name: sast-snyk-check
       runAfter:
-      - clone-repository
+      - build-container
       taskRef:
         params:
         - name: name
@@ -332,6 +332,11 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest


### PR DESCRIPTION
Configure the SAST task to upload SARIF results to quay.io for
long-term storage

Related: 
- https://issues.redhat.com/browse/KONFLUX-3663
- https://issues.redhat.com/browse/KONFLUX-2263